### PR TITLE
Allow filtering for tagged lambda functions with "lambda:function"

### DIFF
--- a/moto/resourcegroupstaggingapi/models.py
+++ b/moto/resourcegroupstaggingapi/models.py
@@ -613,7 +613,11 @@ class ResourceGroupsTaggingAPIBackend(BaseBackend):
         # VPC VPN Connection
 
         # Lambda Instance
-        if not resource_type_filters or "lambda" in resource_type_filters:
+        if (
+            not resource_type_filters
+            or "lambda" in resource_type_filters
+            or "lambda:function" in resource_type_filters
+        ):
             for f in self.lambda_backend.list_functions():
                 tags = format_tags(f.tags)
                 if not tags or not tag_filter(tags):

--- a/tests/test_resourcegroupstaggingapi/test_resourcegroupstaggingapi.py
+++ b/tests/test_resourcegroupstaggingapi/test_resourcegroupstaggingapi.py
@@ -704,6 +704,9 @@ def test_get_resources_lambda():
     resp = rtapi.get_resources(ResourceTypeFilters=["lambda"])
     assert_response(resp, [circle_arn, rectangle_arn])
 
+    resp = rtapi.get_resources(ResourceTypeFilters=["lambda:function"])
+    assert_response(resp, [circle_arn, rectangle_arn])
+
     resp = rtapi.get_resources(TagFilters=[{"Key": "Color", "Values": ["green"]}])
     assert_response(resp, [circle_arn, rectangle_arn])
 


### PR DESCRIPTION
The resource group tagging api `get_resources` doesn't allow for filtering for lambda functions using a `lambda:function` resource type filter, it's only checking for `lambda` - this adds support for that, in the same way it's done for other kinds of resources

First commit has the failing test:
```
        resp = rtapi.get_resources(ResourceTypeFilters=["lambda:function"])
>       assert_response(resp, [circle_arn, rectangle_arn])

tests/test_resourcegroupstaggingapi/test_resourcegroupstaggingapi.py:708: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

response = {'ResourceTagMappingList': [], 'ResponseMetadata': {'HTTPHeaders': {'date': 'Mon, 13 May 2024 11:09:28 GMT', 'server':...Hw8'}, 'HTTPStatusCode': 200, 'RequestId': 'YRtMzouuFVfnMx5K4jhUXR0Of8m1k7vdSQHKA1JcQSdRgKLvQHw8', 'RetryAttempts': 0}}
expected_arns = ['arn:aws:lambda:us-west-2:123456789012:function:lambda-tag-value-1', 'arn:aws:lambda:us-west-2:123456789012:function:lambda-tag-value-2']

    def assert_response(response, expected_arns):
        results = response.get("ResourceTagMappingList", [])
        resultArns = []
        for item in results:
            resultArns.append(item["ResourceARN"])
        for arn in resultArns:
            assert arn in expected_arns
        for arn in expected_arns:
>           assert arn in resultArns
E           AssertionError: assert 'arn:aws:lambda:us-west-2:123456789012:function:lambda-tag-value-1' in []
```